### PR TITLE
Replace pprint/write + with-out-str with shorter (pr-str)

### DIFF
--- a/store.clj
+++ b/store.clj
@@ -2,11 +2,11 @@
  ^{:author "London dojo group"
    :doc "Lowlevel storage"}
  database.store
- (:require [database.database :as database]))
+  (:require [database.database :as database]))
 
 
 (defn store [db obj]
-  (let [s (with-out-str (clojure.pprint/write obj))]
+  (let [s (pr-str obj)]
     '(let [hash ()])))
 
 (defn retrieve [db hash]


### PR DESCRIPTION
I looked at the code a little and I think `(with-out-str (clojure.pprint/write ...`  could be replaced with shorter `(pr-str obj)`